### PR TITLE
fix py311 redis connection error

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ pip install hui_tools[db-orm, db-redis, excel-tools]
 ```python
 extras_require = {
    "db-orm": ["sqlalchemy[asyncio]==2.0.20", "aiomysql==0.2.0"], # 数据库orm
-   "db-redis": ["redis==4.5.4", "aioredis==2.0.1"], # redis
+   "db-redis": ["redis>=4.5.4"], # redis
    "chatbot": ["requests==2.31.0", "cacheout==0.14.1"], # 飞书、钉钉、企业微信机器人通知
    "http-client": ["httpx==0.24.1", "requests==2.31.0"], # http 同步、异步客户端
    "time-tools": ["python-dateutil==2.8.2"], # 时间工具类

--- a/py_tools/connections/db/redis_client.py
+++ b/py_tools/connections/db/redis_client.py
@@ -4,8 +4,9 @@
 # @Desc: { redis连接处理模块 }
 # @Date: 2023/05/03 21:13
 from typing import Optional, Union
-import aioredis
+
 from redis import Redis
+from redis import asyncio as aioredis
 
 
 class RedisManager:
@@ -15,13 +16,13 @@ class RedisManager:
 
     @classmethod
     def init_redis_client(
-            cls,
-            async_client: bool = False,
-            host: str = 'localhost',
-            port: int = 6379,
-            db: int = 0,
-            max_connections: Optional[int] = None,
-            **kwargs
+        cls,
+        async_client: bool = False,
+        host: str = "localhost",
+        port: int = 6379,
+        db: int = 0,
+        max_connections: Optional[int] = None,
+        **kwargs
     ):
         """
         初始化 Redis 客户端。

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,10 +3,9 @@ pandas==1.3.5
 requests==2.31.0
 httpx==0.24.1
 python-dateutil==2.8.2
-loguru==0.7.0
+loguru==0.7.2
 cacheout==0.14.1
-redis==4.5.4
-aioredis==2.0.1
+redis==5.0.1
 pytest==7.3.1
 pydantic==2.1.1
 sqlalchemy[asyncio]==2.0.20

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@
 # @Date: 2023/9/04 19:59
 import operator
 from functools import reduce
+
 from setuptools import find_packages, setup
 
 
@@ -24,10 +25,7 @@ class PKGManager:
     @classmethod
     def get_install_requires(cls):
         """获取必须安装依赖"""
-        requires = [
-            "loguru==0.7.0",
-            "pydantic==2.1.1"
-        ]
+        requires = ["loguru>=0.7.0,<0.8", "pydantic>=2.1.1,<3"]
         return requires
 
     @classmethod
@@ -37,21 +35,18 @@ class PKGManager:
         """
         extras_require = {
             "db-orm": ["sqlalchemy[asyncio]==2.0.20", "aiomysql==0.2.0"],
-            "db-redis": ["redis==4.5.4", "aioredis==2.0.1"],
+            "db-redis": ["redis>=4.5.4"],
             "chatbot": ["requests==2.31.0", "cacheout==0.14.1"],
             "http-client": ["httpx==0.24.1", "requests==2.31.0"],
             "time-tools": ["python-dateutil==2.8.2"],
             "excel-tools": ["pandas==1.3.5", "openpyxl==3.0.10"],
         }
 
-        extras_require["all"] = list(
-            set(reduce(operator.add, [cls.get_install_requires(), *extras_require.values()]))
-        )
+        extras_require["all"] = list(set(reduce(operator.add, [cls.get_install_requires(), *extras_require.values()])))
         return extras_require
 
 
 def main():
-
     setup(
         name=PKGManager.name,
         author=PKGManager.author,
@@ -69,11 +64,11 @@ def main():
             "Operating System :: OS Independent",
         ],
         extras_require=PKGManager.get_extras_require(),
-        python_requires=">=3.7"
+        python_requires=">=3.7",
     )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     # python3 setup.py sdist bdist_wheel
     # twine upload --repository testpypi dist/*
     # twine upload dist/*


### PR DESCRIPTION
Error detail:
```txt
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/mac10.12/github/py-tools/py_tools/connections/db/redis_client.py", line 7, in <module>
    import aioredis
  File "/Users/mac10.12/github/py-tools/venv/lib/python3.11/site-packages/aioredis/__init__.py", line 1, in <module>
    from aioredis.client import Redis, StrictRedis
  File "/Users/mac10.12/github/py-tools/venv/lib/python3.11/site-packages/aioredis/client.py", line 32, in <module>
    from aioredis.connection import (
  File "/Users/mac10.12/github/py-tools/venv/lib/python3.11/site-packages/aioredis/connection.py", line 33, in <module>
    from .exceptions import (
  File "/Users/mac10.12/github/py-tools/venv/lib/python3.11/site-packages/aioredis/exceptions.py", line 14, in <module>
    class TimeoutError(asyncio.TimeoutError, builtins.TimeoutError, RedisError):
TypeError: duplicate base class TimeoutError
```
1. How to reproduce:
```bash
git clone https://github.com/HuiDBK/py-tools
cd py-tools
python3.11 -m venv venv
source venv/bin/activate
pip install -r requirements.txt
python -c 'from py_tools.connections.db.redis_client import RedisManager'
```
2. About the commit:
<img width="930" alt="image" src="https://github.com/HuiDBK/py-tools/assets/35413830/b82a8bdc-f44a-4123-b151-d61495092727">
So we just need to use `from redis import asyncio as aioredis` instead of `import aioredis`